### PR TITLE
Gherkin style syntax

### DIFF
--- a/stylesheets/file-icons.less
+++ b/stylesheets/file-icons.less
@@ -130,10 +130,10 @@
   &[data-name$=".erb"]:before,
   &[data-name$=".opal"]:before   { .ruby-icon; .medium-red; }
 
-  &[data-name$="_spec.rb"]:before { .comment-icon; .medium-green; }
-
   &[data-name$=".pp"]:before { .puppet-icon; .medium-purple }
 
+  // Cucumber (Gherkin) icon
+  &[data-name$=".feature"]:before { .comment-icon; .medium-green; }
 
   // JavaScript icon
   &[data-name$=".js"]:before  { .js-icon; .medium-yellow; }


### PR DESCRIPTION
Can I propose moving the gherkin style comment icon to "feature" files? Ruby files that end in "_spec.rb" aren't always gherkin flavoured.