### PR TITLE
Fix tab bar regression of Atom v 0.172

### DIFF
--- a/stylesheets/items.less
+++ b/stylesheets/items.less
@@ -1,5 +1,5 @@
 // pane tab
-@pane-tab-selector: ~'.pane ul.tab-bar li.tab .title';
+@pane-tab-selector: ~'.pane tabs-bar tabs-tab .title';
 
 @{pane-tab-selector}:before {
   margin-right: 5px;


### PR DESCRIPTION
I wasn't sure if the classes should be kept or if i only should use classnames (for backward compatibility). I decided to use the new custom elements

If you would like to only use classes, then this is the fix:
```less
@pane-tab-selector: ~'.pane .tab-bar .tab .title';
```

Fixes: https://github.com/DanBrooker/file-icons/issues/104