### PR TITLE
Icons missing on tabs in Atom 0.174.0

### DIFF
--- a/stylesheets/file-icons.less
+++ b/stylesheets/file-icons.less
@@ -285,7 +285,7 @@
 }
 
 body.file-icons-colourless {
-  .icon-file-text, .icon-file-directory, .icon-file-media, .icon-book, .pane ul.tab-bar li.tab .title {
+  .icon-file-text, .icon-file-directory, .icon-file-media, .icon-book, atom-pane ul.tab-bar li.tab .title {
     &:before { color: inherit !important; }
   }
 }

--- a/stylesheets/items.less
+++ b/stylesheets/items.less
@@ -1,5 +1,5 @@
 // pane tab
-@pane-tab-selector: ~'.pane tabs-bar tabs-tab .title';
+@pane-tab-selector: ~'atom-pane .tab-bar .tab .title';
 
 @{pane-tab-selector}:before {
   margin-right: 5px;


### PR DESCRIPTION
Hey there, it looks like with the new Atom changes, some selectors aren't catching and the icons are missing from the tabs. This PR includes fixes as suggested by Atom's Deprecation Cop.

![image](https://cloud.githubusercontent.com/assets/1619521/5791724/4c646f0e-9ea7-11e4-9ee6-94de1d776c67.png)

![image](https://cloud.githubusercontent.com/assets/1619521/5791727/75df8aee-9ea7-11e4-97c6-2f487e43c3e8.png)
