### PR TITLE
only show filetype icon for tabs that have a path

### DIFF
--- a/stylesheets/items.less
+++ b/stylesheets/items.less
@@ -1,5 +1,5 @@
 // pane tab
-@pane-tab-selector: ~'atom-pane .tab-bar .tab .title';
+@pane-tab-selector: ~'atom-pane .tab-bar .tab .title[data-path]';
 
 @{pane-tab-selector}:before {
   margin-right: 5px;


### PR DESCRIPTION
Turns out that was easy. Tabs that don't belong to an editor don't have a `data-path` attribute in the title. Since this is only about file-type icons, you can just make the selector a bit more specific.

Fixes #103 

![screen shot 2015-02-09 at 09 14 24](https://cloud.githubusercontent.com/assets/2543659/6102785/554a90c0-b03c-11e4-8403-0be0cb7a07cd.png)
