### PR TITLE
Added jshintignore mapping

### DIFF
--- a/stylesheets/file-icons.less
+++ b/stylesheets/file-icons.less
@@ -104,6 +104,7 @@
   &[data-name=".mailmap"]:before        { .gear-icon;                 }
   &[data-name$=".editorconfig"]:before  { .gear-icon; .medium-orange; }
   &[data-name$=".jshintrc"]:before      { .gear-icon; .medium-yellow; }
+  &[data-name$=".jshintignore"]:before  { .gear-icon;                 }
   &[data-name$=".jscsrc"]:before        { .gear-icon; .medium-yellow; }
   &[data-name$=".module"]:before        { .gear-icon; .medium-blue;   }
   &[data-name$=".htaccess"]:before      { .gear-icon; .medium-red;    }


### PR DESCRIPTION
I use .jshintignore as part of JSHint, it is just a plain text file so didn't add any color to the icon.