### PR TITLE
Added eslint icons

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -105,6 +105,8 @@
   &[data-name$=".editorconfig"]:before  { .gear-icon; .medium-orange; }
   &[data-name$=".jshintrc"]:before      { .gear-icon; .medium-yellow; }
   &[data-name$=".jshintignore"]:before  { .gear-icon;                 }
+  &[data-name$=".eslintrc"]:before      { .gear-icon; .medium-yellow; }
+  &[data-name$=".eslintignore"]:before  { .gear-icon;                 }
   &[data-name$=".jscsrc"]:before        { .gear-icon; .medium-yellow; }
   &[data-name$=".module"]:before        { .gear-icon; .medium-blue;   }
   &[data-name$=".htaccess"]:before      { .gear-icon; .medium-red;    }


### PR DESCRIPTION
Set the `.eslintrc` and `.eslintignore` files to use the gear icon.