### PR TITLE
Align tab icons & keep normal style in temp mode

### DIFF
--- a/styles/items.less
+++ b/styles/items.less
@@ -1,9 +1,14 @@
 // pane tab
 @pane-tab-selector: ~'atom-pane .tab-bar .tab .title[data-path]';
+@pane-tab-temp-selector: ~'atom-pane .tab-bar .tab.temp .title[data-path]';
 
 @{pane-tab-selector}:before {
   margin-right: 5px;
-  vertical-align: middle;
+  vertical-align: baseline;
   //for better visualization in mac os
   -webkit-font-smoothing: antialiased;
+}
+
+@{pane-tab-temp-selector}:before {
+  font-style: normal;
 }


### PR DESCRIPTION
Nice to see icons in tabs finally! :)

I've noticed they are a bit down and also italicized when the tab in temp mode. This PR bring following changes:

### Alignment

before
![screen shot 2015-04-11 at 10 06 58 pm](https://cloud.githubusercontent.com/assets/1355501/7102853/d6a89d56-e098-11e4-8565-dd0bf39a184a.png)
after
![screen shot 2015-04-11 at 10 07 10 pm](https://cloud.githubusercontent.com/assets/1355501/7102857/e021cb82-e098-11e4-94a0-5d9be6dce2f8.png)

### Font style

before
![screen shot 2015-04-11 at 10 11 48 pm](https://cloud.githubusercontent.com/assets/1355501/7102864/061a88e2-e099-11e4-9562-6f4eeea56b4a.png)

after
![screen shot 2015-04-11 at 10 10 53 pm](https://cloud.githubusercontent.com/assets/1355501/7102867/10d5c530-e099-11e4-9c3e-6b3897dc4f40.png)
