### PR TITLE
Add icon for IPython (*.ipy) files.

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -153,6 +153,9 @@
   // Python icon
   &[data-name$=".py"]:before { .python-icon; .dark-yellow; }
 
+  // IPython icon
+  &[data-name$=".ipy"]:before { .python-icon; .dark-blue; }
+
   // Ren'Py (Python)
   &[data-name$=".rpy"]:before { .python-icon; .medium-pink; }
   &[data-name$=".rpyb"]:before { .binary-icon; .medium-red; }
@@ -239,11 +242,11 @@
   // Rust
   &[data-name$=".rs"]:before   { .rust-icon; .medium-maroon; }
   &[data-name$=".rlib"]:before { .rust-icon; .light-maroon; }
-  
+
   //Cargo
   &[data-name$="Cargo.toml"]:before { .package-icon; .light-orange; }
   &[data-name$="Cargo.lock"]:before { .package-icon; .dark-orange; }
-  
+
 
   // Objective-C, C++, C
   &[data-name$=".c"]:before       { .c-icon; .medium-blue; }


### PR DESCRIPTION
I chose dark-blue because of the brackets of the IPython logo.

Thanks for your work!