### PR TITLE
Add support for .cshtml - a C#/ASP.NET Razor file extension

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -110,6 +110,7 @@
   &[data-name$=".ctp"]:before  { .html5-icon; .medium-blue;   }
   &[data-name$=".ejs"]:before  { .html5-icon; .medium-green;  }
   &[data-name$=".swig"]:before  { .html5-icon; .medium-green;  }
+  &[data-name$=".cshtml"]:before { .html5-icon; .medium-red; }
 
   // Mustache icon
   &[data-name$=".hbs"]:before,


### PR DESCRIPTION
Hello,
This PR adds example file for `.cshtml` - a custom extension used for C# based HTML pages using
Razor syntax, a commonly used templating language  in ASP .NET web development.
The icon for `.cshtml` file is using HTML5 icon and medium red color to be somehow similar to
one color from official MS logo colors:

![20150822200002](https://cloud.githubusercontent.com/assets/14539/9425234/967aa330-4909-11e5-839c-57701b98550a.jpg)

I think that used red color is somehow optimal for ASP.NET, as others are either already used or used by Atom to highlight Git changes (so I haven't used green).

Thanks!