### PR TITLE
Revert icon for js files

### DIFF
--- a/styles/icons.less
+++ b/styles/icons.less
@@ -46,7 +46,7 @@
 
 .mf { font-family: "FontMfizz"; font-size: small; text-align: center;  }
 
-.js-icon              { .mf; content: "\f128"; font-size: medium; }
+.js-icon              { .mf; content: "\f148"; font-size: medium; }
 .python-icon          { .mf; content: "\f14c"; }
 .objc-icon            { .mf; content: "\f13e"; font-size: medium; }
 .c-icon               { .mf; content: "\f106"; }


### PR DESCRIPTION
This line seems to be changing the JS files icon to an ... antenna?
https://github.com/DanBrooker/file-icons/commit/65c2accf7195da6f4ee75a434b4453a07ee78cbc#diff-65aa8dfdba97754cb84150bb589dba59R49

<img width="94" alt="screen shot 2015-10-19 at 12 31 53" src="https://cloud.githubusercontent.com/assets/4569111/10576703/34703d22-765d-11e5-855a-e36b8bed88d4.png">
