### PR TITLE
PowerShell module extension correction.

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -411,7 +411,7 @@
   // PowerShell icon
   &[data-name$=".ps1"]:before { .terminal-icon; .medium-blue; }
   &[data-name$=".psd1"]:before { .terminal-icon; .medium-blue; }
-  &[data-name$=".ps1m"]:before { .terminal-icon; .medium-blue; }
+  &[data-name$=".psm1"]:before { .terminal-icon; .medium-blue; }
   &[data-name$=".ps1xml"]:before { .terminal-icon; .medium-blue; }
 
   // Readme


### PR DESCRIPTION
PowerShell Modules have a `.psm1` extension.

See: https://technet.microsoft.com/en-us/library/dd878324

>A script module is a file (.psm1) that contains any valid Windows PowerShell code. Script developers and administrators can use this type of module to create modules whose members include functions, variables, and more.