### PR TITLE
Set JSX file icon to the JSX icon

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -223,10 +223,9 @@
   &[data-name$=".es"]:before  { .js-icon; .medium-yellow; }
 
   // JSX icon
-  &[data-name$=".jsx"]:before { .react-icon; .medium-blue; }
-  &[data-name$=".tsx"]:before { .react-icon; .light-blue; }
+  &[data-name$=".jsx"]:before { .jsx-icon; .medium-blue; }
+  &[data-name$=".tsx"]:before { .jsx-icon; .light-blue; }
   &[data-name$=".react.js"]:before { .react-icon; .medium-blue; }
-  /* &[data-name$=".jsx"]:before { .jsx-icon; .medium-blue; } */
 
   // TypeScript icon
   &[data-name$=".ts"]:before  { .ts-icon; .medium-blue; }

--- a/styles/icons.less
+++ b/styles/icons.less
@@ -157,7 +157,7 @@
 .eslint-icon        { .file-icons; content: "\e90e"; font-size: 14px; left: 1px;}
 .haml-icon          { .file-icons; content: "\f15b"; font-size: 15px; }
 .ionic-icon         { .file-icons; content: "\f14b"; font-size: 18px; left: 1px; }
-.jsx-icon           { .file-icons; content: "\f101"; }
+.jsx-icon           { .file-icons; content: "\f101"; left: -3px; }
 .lein-icon          { .file-icons; content: "\f105"; left: 3px; }
 .nginx-icon         { .file-icons; content:"\f146b"; font-size: 15px; left: 1px; }
 .node-icon          { .file-icons; content: "\f17b"; font-size: 18px; top: 5px; }


### PR DESCRIPTION
I use JSX without React a lot, and I don't like that my JSX files have the React specific logo. Maybe we could change the icon to incorporate the non-opinionated JSX icon?