### PR TITLE
Increase size of Rust icon

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -297,6 +297,8 @@
   // Rust
   &[data-name$=".rs"]:before   { .rust-icon; .medium-maroon; }
   &[data-name$=".rlib"]:before { .rust-icon; .light-maroon; }
+  &.title[data-path][data-name$=".rs"]:before,
+  &.title[data-path][data-name$=".rlib"]:before { vertical-align: -35%; }
 
   // Objective-C, C++, C
   &[data-name$=".c"]:before       { .c-icon; .medium-blue; }

--- a/styles/icons.less
+++ b/styles/icons.less
@@ -103,7 +103,7 @@
 .laravel-icon       { .devicons; content: "\e63f"; }
 .meteor-icon        { .devicons; content: "\e6a5"; font-size: x-large; left: -2px; }
 .rails-icon         { .devicons; content: "\e63b"; }
-.rust-icon          { .devicons; content: "\e6a8"; }
+.rust-icon          { .devicons; content: "\e6a8"; font-size: 22px; line-height: .7; top: 5px; margin-right: 5px; left: -1px; }
 .sass-icon          { .devicons; content: "\e64b"; top: 0; }
 .swift-icon         { .devicons; content: "\e655"; font-size: large; }
 .travis-icon        { .devicons; content: "\e67e"; font-size: medium; }


### PR DESCRIPTION
I've always felt Rust's icon was being displayed a little too small, so I've submitted a PR to adjust it:

<img src="https://cloud.githubusercontent.com/assets/2346707/13198716/4baeac8a-d864-11e5-87e8-0465d35c8444.gif" width="165px" />
