### PR TITLE
Add workspace class to disable Seti UI icons when active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to the project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
-[Unreleased]
+[1.6.16] - 2016-02-27
 ------------
 ### Added
 - **New icons:** OCaml, Lua
+
+### Fixed
+- Icons now display properly with the
+  [Seti UI](https://github.com/jesseweed/seti-ui) theme
 
 ### Changed
 - Composer and Haml icons replaced with silhouetted versions
@@ -564,7 +568,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 Initial release.
 
 
-[Unreleased]: https://github.com/DanBrooker/file-icons/compare/v1.6.15...HEAD
+[Unreleased]: https://github.com/DanBrooker/file-icons/compare/v1.6.16...HEAD
+[1.6.16]: https://github.com/DanBrooker/file-icons/compare/v1.6.15...v1.6.16
 [1.6.15]: https://github.com/DanBrooker/file-icons/compare/v1.6.14...v1.6.15
 [1.6.14]: https://github.com/DanBrooker/file-icons/compare/v1.6.13...v1.6.14
 [1.6.13]: https://github.com/DanBrooker/file-icons/compare/v1.6.12...v1.6.13

--- a/index.coffee
+++ b/index.coffee
@@ -45,34 +45,19 @@ module.exports =
 
   colour: (enable) ->
     body = document.querySelector 'body'
-    if enable
-      body.className = body.className.replace /\sfile-icons-colourless/, ''
-    else
-      body.className = "#{body.className} file-icons-colourless"
+    body.classList.toggle 'file-icons-colourless', !enable
 
   forceShow: (enable) ->
     body = document.querySelector 'body'
-    className = body.className
-    if enable
-      body.className = "#{className} file-icons-force-show-icons"
-    else
-      body.className = className.replace /\sfile-icons-force-show-icons/, ''
+    body.classList.toggle 'file-icons-force-show-icons', enable
 
   onChanges: (enable) ->
     body = document.querySelector 'body'
-    className = body.className
-    if enable
-      body.className = "#{className} file-icons-on-changes"
-    else
-      body.className = className.replace /\sfile-icons-on-changes/, ''
+    body.classList.toggle 'file-icons-on-changes', enable
 
   tabPaneIcon: (enable) ->
     body = document.querySelector 'body'
-    className = body.className
-    if enable
-      body.className = "#{className} file-icons-tab-pane-icon"
-    else
-      body.className = className.replace /\sfile-icons-tab-pane-icon/, ''
+    body.classList.toggle 'file-icons-tab-pane-icon', enable
 
   disableSetiIcons: (disable) ->
     workspaceElement = atom.views.getView(atom.workspace)

--- a/index.coffee
+++ b/index.coffee
@@ -18,6 +18,7 @@ module.exports =
       description: 'Show file icons on tab pane'
 
   activate: (state) ->
+    @disableSetiIcons true
     atom.config.onDidChange 'file-icons.coloured', ({newValue, oldValue}) =>
       @colour newValue
     @colour atom.config.get 'file-icons.coloured'
@@ -36,6 +37,7 @@ module.exports =
     # console.log 'activate'
 
   deactivate: ->
+    @disableSetiIcons false
     # console.log 'deactivate'
 
   serialize: ->
@@ -71,3 +73,7 @@ module.exports =
       body.className = "#{className} file-icons-tab-pane-icon"
     else
       body.className = className.replace /\sfile-icons-tab-pane-icon/, ''
+
+  disableSetiIcons: (disable) ->
+    workspaceElement = atom.views.getView(atom.workspace)
+    workspaceElement.classList.toggle 'seti-ui-no-icons', disable

--- a/index.coffee
+++ b/index.coffee
@@ -38,6 +38,10 @@ module.exports =
 
   deactivate: ->
     @disableSetiIcons false
+    @forceShow false
+    @onChanges false
+    @colour true
+    @tabPaneIcon false
     # console.log 'deactivate'
 
   serialize: ->


### PR DESCRIPTION
This PR simply adds a helper class to the `atom-workspace` element to disable Seti UI's icons when this package is activated.

Granted, this won't do a thing until https://github.com/jesseweed/seti-ui/pull/216 gets merged into upstream.