### PR TITLE
Force icons on tabs

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -34,7 +34,8 @@
 .icon-file-text,
 .icon-file-binary,
 .theme-flatland-dark-ui .icon-file-text,
-.theme-flatland-dark-ui .icon-book {
+.theme-flatland-dark-ui .icon-book,
+.tab.force-file-icon .title /* Allow other packages to force icons from this packages onto tabs */ {
 
   &:before {
     .text-icon;
@@ -137,7 +138,7 @@
   &[data-name$=".hbs"]:before,
   &[data-name$=".handlebars"]:before,
   &[data-name$=".mustache"]:before { .hbs-mustache-icon; .medium-orange; }
-  
+
   // Emblem
   &[data-name$=".emblem"]:before,
   &[data-name$=".em"]:before { .hbs-mustache-icon; .medium-blue; }
@@ -224,8 +225,8 @@
 
   // Cucumber (Gherkin) icon
   &[data-name$=".feature"]:before { .comment-icon; .medium-green; }
-  
-  
+
+
   // JavaScript icon
   &[data-name$=".js"]:before  { .js-icon; .medium-yellow; }
   &[data-name$=".es6"]:before  { .js-icon; .medium-yellow; }
@@ -238,16 +239,16 @@
 
   // TypeScript
   &[data-name$=".ts"]:before  { .ts-icon; .medium-blue; }
-  
+
   // LiveScript
   &[data-name$=".ls"]:before { .ls-icon; .medium-blue; }
-  
+
   // RAML
   &[data-name$=".raml"]:before { .raml-icon; .medium-cyan; }
 
   // Elm icon
   &[data-name$=".elm"]:before { .elm-icon; .medium-blue; }
-  
+
   // Org-mode
   &[data-name$=".org"]:before { .org-icon; .dark-green; }
 
@@ -319,7 +320,7 @@
   &[data-name$=".m"]:before       { .objc-icon; .medium-blue; }
   &[data-name$=".mm"]:before      { .objc-icon; .medium-blue; }
   &[data-name$=".swift"]:before   { .swift-icon; .medium-green; }
-  
+
   // OCaml
   &[data-name$=".ml"]:before      { .ocaml-icon; .medium-orange; }
   &[data-name$=".mli"]:before     { .ocaml-icon; .dark-orange;   }
@@ -328,7 +329,7 @@
   &[data-name$=".ml4"]:before     { .ocaml-icon; .medium-green;  }
   &[data-name$=".mll"]:before     { .ocaml-icon; .dark-green;    }
   &[data-name$=".mly"]:before     { .ocaml-icon; .dark-yellow;   }
-  
+
 
   // D lang
   &[data-name$=".d"]:before     { .dlang-icon; .medium-red; }
@@ -372,7 +373,7 @@
   &[data-name$=".out"]:before,
   &[data-name$=".s"]:before,
   &[data-name$=".asm"]:before { .binary-icon; .medium-red; }
-  
+
   // Linux kernel modules
   &[data-name$=".ko"]:before  { .binary-icon; .dark-green; }
 
@@ -389,7 +390,7 @@
   &[data-name=".zshrc"]:before { .terminal-icon; .medium-blue; }
   &[data-name$=".fish"]:before,
   &[data-name=".fishrc"]:before  { .terminal-icon; .medium-green; }
-  
+
   // Vim
   &[data-name$=".vim"]:before,
   &[data-name$=".nvimrc"]:before,
@@ -420,7 +421,7 @@
   &[data-name$="GULPFILE.babel.js"]:before,
   &[data-name$="Gulpfile.babel.js"]:before,
   &[data-name$="gulpfile.babel.js"]:before  { .gulp-icon; .medium-red; }
-  
+
   // Riot.js
   &[data-name$=".tag"]:before { .riot-icon; .medium-red; }
 
@@ -450,10 +451,10 @@
   // Dockerfile icon
   &[data-name^="Dockerfile"]:before { .docker-icon; .dark-blue; }
   &[data-name$=".dockerignore"]:before { .docker-icon; .dark-blue; }
-  
+
   // Terraform
   &[data-name$=".tf"]:before { .terraform-icon; .dark-purple; }
-  
+
   // SaltStack
   &[data-name$=".sls"]:before { .saltstack-icon; .medium-blue; }
 
@@ -473,7 +474,7 @@
   &[data-name="README.md"]:before,
   &[data-name="Readme.md"]:before,
   &[data-name="readme.md"]:before { .book-icon; .medium-blue; }
-  
+
   // AsciiDoc
   &[data-name$=".adoc"]:before,
   &[data-name$=".asc"]:before,
@@ -508,7 +509,7 @@
   &[data-name$="mpeg"]:before { .video-icon; .medium-red;    }
   &[data-name$="3gpp"]:before { .video-icon; .light-blue;    }
   &[data-name$="ogm"]:before  { .video-icon; .dark-red;      }
-  
+
 
   // Windows specific Files
   &[data-name$=".bat"]:before { .windows-icon; .medium-purple;}


### PR DESCRIPTION
> Added a class that allows other packages to use file-icons as a dependency
> and force file-icons on tabs.

And why this ? Because I use the icons from file-icons for my own package ([pinned-tabs](https://github.com/ericcornelissen/pinned-tabs-for-atom)). And this would allow me to properly use it as a dependency.

One last note: this is how I would implement it, if you feel like implementing it in a different way, feel free to do so :smile: 