### PR TITLE
Improve webpack icon support

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -570,7 +570,7 @@
   &[data-name$=".vue"]:before            { .vue-icon;            .light-green; }
   
   // Webpack
-  &[data-name$="webpack.config.js"]:before { .webpack-icon;     .medium-blue;  }
+  &[data-name^="webpack.config."]:before { .webpack-icon;     .medium-blue;    }
 
   // Windows-specific
   &[data-name$=".bat"]:before            { .windows-icon;      .medium-purple; }


### PR DESCRIPTION
There are lots of examples of code that people write two or more ```webpack.config.*.js``` files, like ```webpack.config.development.js``` and ```webpack.config.production.js```. Webpack also recognises automatically ```webpack.config.babel.js``` and transpiles it with Babel before uses it (I actually use this way).

Perhaps someone can use other extension but ```.js```. I gess begining ```webpack.config.``` is pretty good.