### PR TITLE
Adding extra file extensions

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -66,6 +66,7 @@
   &[data-name$=".scpt"]:before           { .apple-icon;        .medium-purple; }
 
   // AsciiDoc
+  &[data-name$=".ad"]:before,
   &[data-name$=".adoc"]:before,
   &[data-name$=".asc"]:before,
   &[data-name$=".asciidoc"]:before       { .asciidoc-icon;       .medium-blue; }
@@ -156,9 +157,9 @@
   
   // Emacs Lisp
   &[data-name$=".emacs"]:before,
+  &[data-name$=".spacemacs"]:before,
   &[data-name$=".emacs.desktop"]:before,
   &[data-name$=".el"]:before             { .emacs-icon;        .medium-purple; }
-  
 
   // Emblem
   &[data-name$=".emblem"]:before,


### PR DESCRIPTION
Hi,

Adding .ad file extension for asciidoc and .spacemacs for Emacs Lisp, as they were missing. 

Thanks for your time,
Brenton