### PR TITLE
Support Composer Executables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 -------------
 ### Added
 - **New icons:** BYOND, Clean, Click, Coq, Creole, Cython, Darcs, Diff, E, Eagle, Ecere, Eiffel, EmberScript, Factor, Fancy, Fantom, Flux, FreeMarker, Frege, Gentoo, NVIDIA, Patch, Perl 6
-- **Support:** Cycript (`.cy`), DNS Zones (`.arpa`, `.zone`), Dust (`.dust`), Dylan (`.dylan`, `.dyl`, `.intr`, `.lid`), ECL (`.ecl`, `.eclxml`), Formatted (`.eam.fs`), Forth (`.4th`, `.fth`, `.forth`, `.frt`), G-code (`.gco`, `.gcode`)
+- **Support:** Cycript (`.cy`), DNS Zones (`.arpa`, `.zone`), Dust (`.dust`), Dylan (`.dylan`, `.dyl`, `.intr`, `.lid`), ECL (`.ecl`, `.eclxml`), Formatted (`.eam.fs`), Forth (`.4th`, `.fth`, `.forth`, `.frt`), G-code (`.gco`, `.gcode`), Composer executable (`composer.phar`)
 
 ### Changed
 - Generic config icon now used for `.conf` files instead of nginx logo [[`#331`](https://github.com/DanBrooker/file-icons/issues/331)]

--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -1207,6 +1207,7 @@
   &[data-name="riemann.config"]:before   { .clojure-icon;       .auto(maroon); }
 
   // Composer
+  &[data-name="composer.phar"]:before,
   &[data-name="composer.json"]:before,
   &[data-name="composer.lock"]:before    { .composer-icon;     .medium-yellow; }
 


### PR DESCRIPTION
Add support for files named `composer.phar` exactly. [`CHANGELOG`](https://github.com/zanderbaldwin/file-icons/blob/e01a4d45b3a140c20ae395acfdc6b34301e5ed22/CHANGELOG.md) has been updated.