### PR TITLE
Add hamlc extension for haml icon

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -677,6 +677,7 @@
   &[data-name$=".htm"]:before            { .html5-icon;        .medium-orange; }
   &[data-name$=".shtml"]:before          { .html5-icon;          .medium-cyan; }
   &[data-name$=".haml"]:before           { .haml-icon;         .medium-yellow; }
+  &[data-name$=".hamlc"]:before          { .haml-icon;         .medium-maroon; }
   &[data-name$=".jsp"]:before            { .html5-icon;        .medium-purple; }
   &[data-name$=".ctp"]:before            { .html5-icon;          .medium-blue; }
   &[data-name$=".ejs"]:before            { .html5-icon;         .medium-green; }


### PR DESCRIPTION
For people using https://github.com/netzpirat/haml-coffee or https://github.com/emilioforrer/haml_coffee_assets to write haml files in coffeescript templates (used with angular etc)