### PR TITLE
Fix PDF on colourless setting, and center align the icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - **Support:** Embedded Crystal (`.coffee.ecr`, `.htm.ecr`, `.html.ecr`, `.js.ecr`), Embedded Ruby (`.htm.erb`), SQLite (`.sqlite`, `.sqlite3`, `.db`, `.db3`)
 
+### Changed
+- Alignment tweaked for PDF icon
+
+### Fixed
+- PDF files now respect value of user's "Coloured" setting
+
 
 [1.7.10 - 2016-05-07]
 ---------------------

--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -10,7 +10,8 @@
 .icon-file-text,
 .icon-file-directory,
 .icon-file-media,
-.icon-book {
+.icon-book,
+.icon-file-pdf {
   &:before { text-align: center; }
 }
 
@@ -2023,6 +2024,7 @@ body.file-icons-colourless {
   .icon-file-media,
   .icon-file-binary,
   .icon-book,
+  .icon-file-pdf,
   atom-pane ul.tab-bar li.tab .title {
     &:before { color: inherit !important; }
   }


### PR DESCRIPTION
Currently, the PDF icon displays in colour regardless of the "Coloured" setting, and is aligned to the left (should be in the center). This PR fixes both those issues.