### PR TITLE
Add in support for ZSH config files without the dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [Unpublished]
 -------------
 ### Added
-- **Support:** Embedded Crystal (`.coffee.ecr`, `.htm.ecr`, `.html.ecr`, `.js.ecr`), Embedded Ruby (`.htm.erb`), SQLite (`.sqlite`, `.sqlite3`, `.db`, `.db3`)
+- **Support:** Embedded Crystal (`.coffee.ecr`, `.htm.ecr`, `.html.ecr`, `.js.ecr`), Embedded Ruby (`.htm.erb`), SQLite (`.sqlite`, `.sqlite3`, `.db`, `.db3`), ZSH (`zlogin`, `zlogout`, `zprofile`, `zshenv`, `zshrc`)
 
 ### Changed
 - Alignment tweaked for PDF icon

--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -1574,12 +1574,12 @@
   &[data-name="PKGBUILD"]:before         { .terminal-icon;     .medium-purple; }
   &[data-name$=".ksh"]:before            { .terminal-icon;       .dark-yellow; }
   &[data-name$=".sh-session"]:before     { .terminal-icon;      .auto(yellow); }
-  &[data-name$=".zsh"]:before,
-  &[data-name=".zlogin"]:before,
-  &[data-name=".zlogout"]:before,
-  &[data-name=".zprofile"]:before,
-  &[data-name=".zshenv"]:before,
-  &[data-name=".zshrc"]:before           { .terminal-icon;       .medium-blue; }
+  &[data-name="zlogin"]:before,          &[data-name=".zlogin"]:before,
+  &[data-name="zlogout"]:before,         &[data-name=".zlogout"]:before,
+  &[data-name="zprofile"]:before,        &[data-name=".zprofile"]:before,
+  &[data-name="zshenv"]:before,          &[data-name=".zshenv"]:before,
+  &[data-name="zshrc"]:before,           &[data-name=".zshrc"]:before,
+  &[data-name$=".zsh"]:before            { .terminal-icon;       .medium-blue; }
   &[data-name$=".fish"]:before,
   &[data-name=".fishrc"]:before          { .terminal-icon;      .medium-green; }
   &[data-name$=".sh.in"]:before          { .terminal-icon;          .dark-red; }


### PR DESCRIPTION
Similar to how the Bash config files are handled, all the ZSH config files without the dot now display the shell icon properly