### PR TITLE
Add in support for more Node, Python and Ruby files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [Unpublished]
 -------------
 ### Added
-- **Support:** Embedded Crystal (`.coffee.ecr`, `.htm.ecr`, `.html.ecr`, `.js.ecr`), Embedded Ruby (`.htm.erb`), Node.js/NPM (`.node-version`, `npmrc`), Python (`pypirc`, `.pypirc`, `pythonrc`, `.pythonrc`, `.python-venv`), Ruby (`gemrc`, `pryrc`, `rspec`), SQLite (`.sqlite`, `.sqlite3`, `.db`, `.db3`), ZSH (`zlogin`, `zlogout`, `zprofile`, `zshenv`, `zshrc`)
+- **Support:** Embedded Crystal (`.coffee.ecr`, `.htm.ecr`, `.html.ecr`, `.js.ecr`), Embedded Ruby (`.htm.erb`), NodeJS (`.node-version`), NPM (`npmrc`), Python (`pypirc`, `.pypirc`, `pythonrc`, `.pythonrc`, `.python-venv`), Ruby (`gemrc`, `pryrc`, `rspec`), SQLite (`.sqlite`, `.sqlite3`, `.db`, `.db3`), ZSH (`zlogin`, `zlogout`, `zprofile`, `zshenv`, `zshrc`)
 
 ### Changed
 - Size/alignment tweaked for PDF and Python icons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [Unpublished]
 -------------
 ### Added
-- **Support:** Embedded Crystal (`.coffee.ecr`, `.htm.ecr`, `.html.ecr`, `.js.ecr`), Embedded Ruby (`.htm.erb`), SQLite (`.sqlite`, `.sqlite3`, `.db`, `.db3`), ZSH (`zlogin`, `zlogout`, `zprofile`, `zshenv`, `zshrc`)
+- **Support:** Embedded Crystal (`.coffee.ecr`, `.htm.ecr`, `.html.ecr`, `.js.ecr`), Embedded Ruby (`.htm.erb`), Node.js/NPM (`.node-version`, `npmrc`), Python (`pypirc`, `.pypirc`, `pythonrc`, `.pythonrc`, `.python-venv`), Ruby (`gemrc`, `pryrc`, `rspec`), SQLite (`.sqlite`, `.sqlite3`, `.db`, `.db3`), ZSH (`zlogin`, `zlogout`, `zprofile`, `zshenv`, `zshrc`)
 
 ### Changed
 - Size/alignment tweaked for PDF and Python icons
+- Python icon used for `.python-version` files
 
 ### Fixed
 - PDF files now respect value of user's "Coloured" setting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Support:** Embedded Crystal (`.coffee.ecr`, `.htm.ecr`, `.html.ecr`, `.js.ecr`), Embedded Ruby (`.htm.erb`), SQLite (`.sqlite`, `.sqlite3`, `.db`, `.db3`), ZSH (`zlogin`, `zlogout`, `zprofile`, `zshenv`, `zshrc`)
 
 ### Changed
-- Alignment tweaked for PDF icon
+- Size/alignment tweaked for PDF and Python icons
 
 ### Fixed
 - PDF files now respect value of user's "Coloured" setting

--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -506,7 +506,6 @@
   &[data-name$=".yardopts"]:before       { .gear-icon;            .medium-red; }
   &[data-name$=".codoopts"]:before       { .gear-icon;         .medium-maroon; }
   &[data-name=".pairs"]:before           { .gear-icon;            .dark-green; }
-  &[data-name=".python-version"]:before  { .gear-icon;             .dark-blue; }
   &[data-name$=".ctags"]:before          { .gear-icon;           .dark-purple; }
 
   // Generic format: Audio
@@ -1168,7 +1167,8 @@
   &[data-name=".nodemonignore"]:before   { .gear-icon;          .medium-green; }
 
   // NPM (Node.js)
-  &[data-name=".npmrc"]:before           { .npm-icon;             .medium-red; }
+  &[data-name=".node-version"]:before,
+  &[data-name="npmrc"]:before,           &[data-name=".npmrc"]:before,
   &[data-name=".npmignore"]:before       { .npm-icon;             .medium-red; }
   &[data-name="npm-debug.log"]:before    { .npm-icon;             .medium-red; }
   &[data-name="package.json"]:before     { .npm-icon;             .medium-red; }
@@ -1384,6 +1384,9 @@
   &[data-name$=".purs"]:before           { .purescript-icon;     .dark-purple; }
 
   // Python
+  &[data-name="pypirc"]:before,          &[data-name=".pypirc"]:before,
+  &[data-name="pythonrc"]:before,        &[data-name=".pythonrc"]:before,
+  &[data-name=".python-venv"]:before,    &[data-name=".python-version"]:before,
   &[data-name$=".py"]:before             { .python-icon;           .dark-blue; }
   &[data-name$=".bzl"]:before            { .python-icon;           .dark-blue; }
   &[data-name$=".ipy"]:before            { .python-icon;         .medium-blue; }
@@ -1482,8 +1485,9 @@
   &[data-name$=".rss"]:before            { .rss-icon;          .medium-orange; }
 
   // Ruby
-  &[data-name=".gemrc"]:before,
-  &[data-name=".pryrc"]:before,          &[data-name=".rspec"]:before,
+  &[data-name="gemrc"]:before,           &[data-name=".gemrc"]:before,
+  &[data-name="pryrc"]:before,           &[data-name=".pryrc"]:before,
+  &[data-name="rspec"]:before,           &[data-name=".rspec"]:before,
   &[data-name=".ruby-gemset"]:before,    &[data-name=".ruby-version"]:before,
   &[data-name="Appraisals"]:before,      &[data-name="Berksfile"]:before,
   &[data-name="buildfile"]:before,       &[data-name="Buildfile"]:before,

--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -1162,12 +1162,14 @@
   // Nmap (Lua)
   &[data-name$=".nse"]:before            { .nmap-icon;             .dark-blue; }
 
+  // NodeJS
+  &[data-name=".node-version"]:before    { .node-icon;          .medium-green; }
+
   // Nodemon
   &[data-name="nodemon.json"]:before,
   &[data-name=".nodemonignore"]:before   { .gear-icon;          .medium-green; }
 
   // NPM (Node.js)
-  &[data-name=".node-version"]:before,
   &[data-name="npmrc"]:before,           &[data-name=".npmrc"]:before,
   &[data-name=".npmignore"]:before       { .npm-icon;             .medium-red; }
   &[data-name="npm-debug.log"]:before    { .npm-icon;             .medium-red; }

--- a/styles/icons.less
+++ b/styles/icons.less
@@ -95,7 +95,7 @@
 .objc-icon            { .mf; content: "\f13e"; font-size: medium; }
 .osx-icon             { .mf; content: "\f141"; left: 2px; }
 .perl-icon            { .mf; content: "\f142"; }
-.python-icon          { .mf; content: "\f14c"; }
+.python-icon          { .mf; content: "\f14c"; font-size: medium; left: 1px; }
 .red-hat-icon         { .mf; content: "\f14e"; }
 .scala-icon           { .mf; content: "\f154"; left: 3px; top: 2px; font-size: medium; }
 .sql-icon             { .mf; content: "\f10e"; left: 3px; }


### PR DESCRIPTION
- Adjusted size/alignment of the Python icon (current one is too small)
- Added in quite a few icon listings for Node, Python and Ruby files