### PR TITLE
Adding zsh-theme file extension

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -1585,6 +1585,7 @@
   &[data-name="zprofile"]:before,        &[data-name=".zprofile"]:before,
   &[data-name="zshenv"]:before,          &[data-name=".zshenv"]:before,
   &[data-name="zshrc"]:before,           &[data-name=".zshrc"]:before,
+  &[data-name$=".zsh-theme"]:before,
   &[data-name$=".zsh"]:before            { .terminal-icon;       .medium-blue; }
   &[data-name$=".fish"]:before,
   &[data-name=".fishrc"]:before          { .terminal-icon;      .medium-green; }


### PR DESCRIPTION
Adding the `.zsh-theme` file extension to the list of Zsh shell script file types.