### PR TITLE
Add support for preprocessed FORTRAN file extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 -------------
 ### Added
 - **New icons:** C# Cake, C#-Script, Cucumber/Gherkin, NAnt, Protractor, Strings, Typings
-- **Support:** Config files (`.htmlhintrc`), Git commit/merge messages (`COMMIT_EDITMSG`, `MERGE_HEAD`, `MERGE_MODE`, `MERGE_MSG`)
+- **Support:** Config files (`.htmlhintrc`), Git commit/merge messages (`COMMIT_EDITMSG`, `MERGE_HEAD`, `MERGE_MODE`, `MERGE_MSG`), Preprocessed FORTRAN (`.F`, `.F77`, `.F90`, `.F95`, `.F03`, `.F08`, `.FOR`, `.FPP`)
 
 ### Changed
 - Cakefile class-name changed from `.cake` to `.cakefile` to accommodate C#'s "cake"

--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -464,14 +464,22 @@
   &[data-name$=".flux"]:before           { .flux-icon;             .dark-blue; }
 
   // FORTRAN
-  &[data-name$=".f"]:before              { .fortran-icon;      .medium-maroon; }
-  &[data-name$=".f90"]:before            { .fortran-icon;       .medium-green; }
-  &[data-name$=".f03"]:before            { .fortran-icon;         .medium-red; }
-  &[data-name$=".f08"]:before            { .fortran-icon;        .medium-blue; }
-  &[data-name$=".f77"]:before            { .fortran-icon;      .medium-maroon; }
-  &[data-name$=".f95"]:before            { .fortran-icon;          .dark-pink; }
-  &[data-name$=".for"]:before            { .fortran-icon;          .dark-cyan; }
-  &[data-name$=".fpp"]:before            { .fortran-icon;        .dark-yellow; }
+  &[data-name$=".f"]:before,
+  &[data-name$=".F"]:before              { .fortran-icon;      .medium-maroon; }
+  &[data-name$=".f90"]:before,
+  &[data-name$=".F90"]:before            { .fortran-icon;       .medium-green; }
+  &[data-name$=".f03"]:before,
+  &[data-name$=".F03"]:before            { .fortran-icon;         .medium-red; }
+  &[data-name$=".f08"]:before,
+  &[data-name$=".F08"]:before            { .fortran-icon;        .medium-blue; }
+  &[data-name$=".f77"]:before,
+  &[data-name$=".F77"]:before            { .fortran-icon;      .medium-maroon; }
+  &[data-name$=".f95"]:before,
+  &[data-name$=".F95"]:before            { .fortran-icon;          .dark-pink; }
+  &[data-name$=".for"]:before,
+  &[data-name$=".FOR"]:before            { .fortran-icon;          .dark-cyan; }
+  &[data-name$=".fpp"]:before,
+  &[data-name$=".FPP"]:before            { .fortran-icon;        .dark-yellow; }
   
   // FreeMarker
   &[data-name$=".ftl"]:before            { .freemarker-icon;     .medium-blue; }


### PR DESCRIPTION
Add uppercase FORTRAN file extensions. Many compilers use file extension case to indicate preprocessing for FORTRAN.