### PR TITLE
Adding .config and .emacs.d folders, adding Manifest to Gentoo filetypes

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -39,11 +39,20 @@
   // Atom
   &[data-name=".atom"]:before { .atom-icon; }
 
+  // Config
+  &[data-name=".config"]:before { .config-icon; .medium-cyan; }
+
+  // Emacs
+  &[data-name=".emacs.d"]:before { .emacs-icon; }
+
   // Git
   &[data-name=".git"]:before     { .git-icon; }
 
   // GitHub
   &[data-name=".github"]:before  { .github-icon; }
+
+  // Oh My Zsh
+  &[data-name=".oh-my-zsh"]:before { .terminal-icon; .medium-blue; }
 
   // Package
   &[data-name=".bundle"]:before  { .package-icon; }
@@ -825,6 +834,7 @@
   // Gentoo Linux
   &[data-name$=".ebuild"]:before         { .gentoo-icon;           .dark-cyan; }
   &[data-name$=".eclass"]:before         { .gentoo-icon;         .medium-blue; }
+  &[data-name="Manifest"]:before         { .gentoo-icon;        .light-purple; }
 
   // Git
   &[data-name^=".git"]:before,


### PR DESCRIPTION
Hi,

In this commit I am adding the `config-icon` to `.config` folders. I also am adding the emacs icon to folders with the name `.emacs.d`. I lastly added the file name `Manifest` to the Gentoo filetype. 

Thanks for your time,
Brenton