### PR TITLE
Adding Ubuntu icons for Snappy package files

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -1793,7 +1793,7 @@
 
   // Shopify
   &[data-name$=".liquid"]:before         { .shopify-icon;       .medium-green; }
-  
+
   // Sigils
   &[data-name$=".sigils"]:before         { .sigils-icon;            .dark-red; }
 
@@ -1988,6 +1988,10 @@
 
   // TypeScript
   &[data-name$=".ts"]:before             { .ts-icon;             .medium-blue; }
+
+  // Ubuntu
+  &[data-name="snapcraft.yaml"]:before   { .ubuntu-icon;           .dark-cyan; }
+  &[data-name$=".snap"]:before           { .ubuntu-icon;        .medium-green; }
 
   // Unity3D
   &[data-name$=".anim"]:before           { .unity3d-icon;          .dark-blue; }

--- a/styles/icons.less
+++ b/styles/icons.less
@@ -103,8 +103,7 @@
 .sql-icon             { .mf; content: "\f10e"; left: 3px; }
 .svg-icon             { .mf; content: "\f15c"; }
 .tt-icon              { .mf; content: "TT";    }
-
-
+.ubuntu-icon          { .mf; content: "\f16a"; font-size: 15px; }
 
 /*============================================================================*
   IcoMoon's default icon library


### PR DESCRIPTION
Hi,

In this commit I am adding Ubuntu icons and using them for Snappy package files (namely snapcraft.yaml and .snap files). 

Thanks for your time,
Brenton