### PR TITLE
Add .eslintcache icon

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -493,6 +493,7 @@
   &[data-name$=".eslintrc.yaml"]:before,
   &[data-name$=".eslintrc.yml"]:before   { .eslint-icon;         .light-purple }
   &[data-name$=".eslintignore"]:before   { .eslint-icon;        .medium-purple }
+  &[data-name$=".eslintcache"]:before    { .eslint-icon;        .medium-purple }
 
   // Factor
   &[data-name$=".factor"]:before         { .factor-icon;       .medium-orange; }


### PR DESCRIPTION
This just adds the eslint icon (which needs to be updated to the new logo, but will do that on https://github.com/Alhadis/FileIcons repo) to `.eslintcache` files.