### PR TITLE
Add support for Mocha .opts extension

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -1279,6 +1279,9 @@
   &[data-name$=".mir"]:before,
   &[data-name$=".mirah"]:before          { .mirah-icon;           .light-blue; }
 
+  // Mocha
+  &[data-name$=".opts"]:before           { .mocha-icon;         .light-maroon; }
+
   // Modelica
   &[data-name$=".mo"]:before             { .circle-icon;           .light-red; }
 

--- a/styles/icons.less
+++ b/styles/icons.less
@@ -345,6 +345,7 @@
 .meteor-icon        { .file-icons; content: "\e6a5"; font-size: 15px; left: 1px; top: 1px; }
 .minecraft-icon     { .file-icons; content: "\e9dc"; font-size: 15px; }
 .mirah-icon         { .file-icons; content: "\e995"; font-size: 15px; }
+.mocha-icon         { .file-icons; content: "\26fe"; font-size: 15px; }
 .model-icon         { .file-icons; content: "\e9e8"; font-size: 16px; }
 .modula2-icon       { .file-icons; content: "\e996"; font-size: 15px; }
 .monkey-icon        { .file-icons; content: "\e997"; font-size: 18px; top: 4px; left: -1px; }


### PR DESCRIPTION
> Back on the server, Mocha will attempt to load ./test/mocha.opts as a configuration file of sorts. 