### PR TITLE
Added .dsql file detection

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -1877,6 +1877,7 @@
   &[data-name$=".viw"]:before,
   &[data-name$=".db2"]:before,
   &[data-name$=".prc"]:before            { .sql-icon; }
+  &[data-name$=".dsql"]:before           { .sql-icon;           .light-purple; }
   &[data-name$=".pls"]:before,           // PLSQL
   &[data-name$=".pck"]:before,
   &[data-name$=".pks"]:before,


### PR DESCRIPTION
.dsql is used by Microsoft's Parallel Data Warehouse. For lack of a corporate branding, a little bit of google search yielded a lean towards purple. So here it is as light-purple. Anyway - the focus is on differentiation from the standard sql icon rather than a specific colour.

