### PR TITLE
Add icon for .vagrant directory

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -56,6 +56,9 @@
 
   // Bower Components
   &[data-name="bower_components"]:before { .bower-icon; .auto(bower); }
+
+  // Vagrant
+  &[data-name=".vagrant"]:before { .vagrant-icon; }
 }
 
 


### PR DESCRIPTION
There is already icon for `Vagrantfile` so I added the same icon for `.vagrant` directory

<img width="170" alt="screen shot 2016-10-05 at 2 17 58 pm" src="https://cloud.githubusercontent.com/assets/901000/19111139/95c22d06-8b06-11e6-9f72-41494692eee1.png">
