### PR TITLE
Add Terraform icon to .tfvars files

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -2004,6 +2004,7 @@
 
   // Terraform
   &[data-name$=".tf"]:before             { .terraform-icon;      .dark-purple; }
+  &[data-name$=".tfvars"]:before         { .terraform-icon;      .dark-purple; }
 
   // TeX
   &[data-name$=".tex"]:before            { .tex-icon;             .auto(blue); }


### PR DESCRIPTION
Hashicorp Terraform supports `.tfvars` file extension in addition to standard `.tf` - this PR adds standard Terraform icon for these files.
`.tfvars` support is being mentioned in official Terraform documentation: https://www.terraform.io/intro/getting-started/variables.html