### PR TITLE
Add support for Bowerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Change Log
 All notable changes to the project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+[Unreleased]
+---------------------
+### Added
+- **Support:** Bower Rails (`Bowerfile`)
+
 
 [1.7.22] - 2016-10-14
 ---------------------

--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -2245,6 +2245,7 @@
   // Bower
   &[data-name=".bowerrc"]:before         { .bower-icon;                        }
   &[data-name="bower.json"]:before       { .bower-icon;          .auto(bower); }
+  &[data-name="Bowerfile"]:before       { .bower-icon;           .auto(bower); }
 
   // Brakeman
   &[data-name$="brakeman.yml"]:before    { .brakeman-icon;        .medium-red; }


### PR DESCRIPTION
Uses existing Bower icon for:
* [Bowerfile](https://github.com/rharriso/bower-rails#ruby-dsl-configuration) is used by Bower Rails as a DSL configuration file.