### PR TITLE
Add support for .antigen and .zpreztorc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [Unreleased]
 ---------------------
 ### Added
-- **Support:** Bower Rails (`Bowerfile`), Docker Compose (`.docker-compose.*`), Docker Sync (`docker-sync.yml`), PostCSS (`.postcssrc`, `postcss.config.js`)
+- **Support:** Bower Rails (`Bowerfile`), Docker Compose (`.docker-compose.*`), Docker Sync (`docker-sync.yml`), PostCSS (`.postcssrc`, `postcss.config.js`), Zsh (`.antigen`, `.zpreztorc`)
 
 
 [1.7.22] - 2016-10-14

--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -1845,8 +1845,10 @@
   &[data-name="bash_history"]:before,    &[data-name=".bash_history"]:before,
   &[data-name$=".ksh"]:before            { .terminal-icon;       .dark-yellow; }
   &[data-name$=".sh-session"]:before     { .terminal-icon;      .auto(yellow); }
+  &[data-name="antigen"]:before,         &[data-name=".antigen"]:before,
   &[data-name="zlogin"]:before,          &[data-name=".zlogin"]:before,
   &[data-name="zlogout"]:before,         &[data-name=".zlogout"]:before,
+  &[data-name="zpreztorc"]:before,       &[data-name=".zpreztorc"]:before,
   &[data-name="zprofile"]:before,        &[data-name=".zprofile"]:before,
   &[data-name="zshenv"]:before,          &[data-name=".zshenv"]:before,
   &[data-name="zshrc"]:before,           &[data-name=".zshrc"]:before,


### PR DESCRIPTION
Uses existing Zsh icon for:
- [`Antigen`](https://github.com/zsh-users/antigen) - A plugin manager
for zsh
- [`Prezto`](https://github.com/sorin-ionescu/prezto) - The
configuration framework for Zsh