### PR TITLE
JavaScript: Add .mjs extension support

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -1031,6 +1031,7 @@
   &[data-name$="._js"]:before            { .js-icon;            .auto(orange); }
   &[data-name$=".jsb"]:before            { .js-icon;            .auto(maroon); }
   &[data-name$=".jsm"]:before            { .js-icon;              .auto(blue); }
+  &[data-name$=".mjs"]:before            { .js-icon;              .auto(blue); }
   &[data-name$=".jss"]:before            { .js-icon;             .auto(green); }
   &[data-name$=".es6"]:before            { .js-icon;            .auto(yellow); }
   &[data-name$=".es"]:before             { .js-icon;            .auto(yellow); }


### PR DESCRIPTION
`.mjs` seems to be the current candidate for the ES2015 module extension in Node.js - let's add support for it.

I found [this article](https://nodesource.com/blog/es-modules-and-node-js-hard-choices) that backs up this claim, if it is of interest. :)

Thanks!