### PR TITLE
Add support for Vash template files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Change Log
 All notable changes to the project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+[Unreleased]
+---------------------
+### Added
+- **Support:** Vash templates (`.vash`)
 
 [1.7.25] - 2016-11-13
 ---------------------

--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -985,6 +985,7 @@
   &[data-name$=".scaml"]:before          { .html5-icon;             .dark-red; }
   &[data-name$=".latte"]:before          { .html5-icon;           .medium-red; }
   &[data-name$=".kit"]:before            { .html5-icon;         .medium-green; }
+  &[data-name$=".vash"]:before           { .html5-icon;           .medium-red; }
 
   // Hy
   &[data-name$=".hy"]:before             { .hy-icon;               .dark-blue; }


### PR DESCRIPTION
[Vash](https://github.com/kirbysayshi/vash) is a [Razor Syntax](https://www.asp.net/web-pages/overview/getting-started/introducing-razor-syntax-c)-based template engine that has been recently introduced in the alternatives offered by the [Express application generator](https://expressjs.com/en/starter/generator.html).

Nothing too fancy in this PR, just used the standard HTML icon with a red colour, since `.vash` files are kind of similar to `.cshtml`.

I'm not sure I understand the part "*remember to replace [Unreleased] with the name of the version you're cutting*" in the `CONTRIBUTING.md` guide, but here's my shot at it.

File-icons is one of the plugins that make Atom great, so thanks and keep up the good work!